### PR TITLE
fix: correct installation script URLs from ddx-tools/ddx to easel/ddx

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ DDX (Document-Driven Development eXperience) is a CLI toolkit that revolutionize
 
 **One-line installation:**
 ```bash
-curl -fsSL https://raw.githubusercontent.com/ddx-tools/ddx/main/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/easel/ddx/main/install.sh | bash
 ```
 
 **Initialize in your project:**
@@ -353,7 +353,7 @@ Projects using DDX report:
 
 ### Quick Install (Recommended)
 ```bash
-curl -fsSL https://raw.githubusercontent.com/ddx-tools/ddx/main/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/easel/ddx/main/install.sh | bash
 ```
 
 ### Package Managers
@@ -362,10 +362,10 @@ curl -fsSL https://raw.githubusercontent.com/ddx-tools/ddx/main/install.sh | bas
 brew install ddx
 
 # Go install
-go install github.com/ddx-tools/ddx/cli@latest
+go install github.com/easel/ddx/cli@latest
 
 # From source
-git clone https://github.com/ddx-tools/ddx
+git clone https://github.com/easel/ddx
 cd ddx/cli
 make install
 ```
@@ -382,7 +382,7 @@ DDX uses a simple YAML configuration file (`.ddx.yml`):
 ```yaml
 # .ddx.yml
 version: "1.0"
-repository: https://github.com/ddx-tools/ddx-master
+repository: https://github.com/easel/ddx-master
 branch: main
 
 # Resources to include
@@ -423,8 +423,8 @@ This creates a pull request to the master repository where it can benefit the en
 ### Getting Help
 
 - **Documentation**: [docs.ddx.dev](https://docs.ddx.dev)
-- **Issues**: [GitHub Issues](https://github.com/ddx-tools/ddx/issues)
-- **Discussions**: [GitHub Discussions](https://github.com/ddx-tools/ddx/discussions)
+- **Issues**: [GitHub Issues](https://github.com/easel/ddx/issues)
+- **Discussions**: [GitHub Discussions](https://github.com/easel/ddx/discussions)
 - **Discord**: [Join our Discord](https://discord.gg/ddx)
 
 ### Philosophy
@@ -480,7 +480,7 @@ Special thanks to all contributors who share their knowledge and help make devel
 **Ready to revolutionize your development workflow?**
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/ddx-tools/ddx/main/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/easel/ddx/main/install.sh | bash
 ```
 
 *Join thousands of developers who never lose their best work again.*

--- a/docs/SETUP_GUIDE.md
+++ b/docs/SETUP_GUIDE.md
@@ -1323,7 +1323,7 @@ echo $SHELL
 
 #### Method 1: Quick Install (Recommended)
 ```bash
-curl -fsSL https://raw.githubusercontent.com/ddx-tools/ddx/main/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/easel/ddx/main/install.sh | bash
 ```
 
 This script:
@@ -1335,7 +1335,7 @@ This script:
 #### Method 2: Homebrew
 ```bash
 # Add DDX tap
-brew tap ddx-tools/ddx
+brew tap easel/ddx
 
 # Install DDX
 brew install ddx
@@ -1344,13 +1344,13 @@ brew install ddx
 #### Method 3: Go Install
 ```bash
 # Requires Go 1.21+
-go install github.com/ddx-tools/ddx/cli@latest
+go install github.com/easel/ddx/cli@latest
 ```
 
 #### Method 4: From Source
 ```bash
 # Clone repository
-git clone https://github.com/ddx-tools/ddx
+git clone https://github.com/easel/ddx
 cd ddx/cli
 
 # Build and install
@@ -1563,7 +1563,7 @@ git init
 # Manually create config
 cat > .ddx.yml << 'EOF'
 version: "1.0"
-repository: https://github.com/ddx-tools/ddx-master
+repository: https://github.com/easel/ddx-master
 branch: main
 EOF
 ```
@@ -1581,7 +1581,7 @@ ddx list --verbose
 
 #### DDX Help Resources
 - **Documentation**: Run `ddx help <command>`
-- **GitHub Issues**: [github.com/ddx-tools/ddx/issues](https://github.com/ddx-tools/ddx/issues)
+- **GitHub Issues**: [github.com/easel/ddx/issues](https://github.com/easel/ddx/issues)
 - **Discord Community**: [discord.gg/ddx](https://discord.gg/ddx)
 
 #### Claude Code Help


### PR DESCRIPTION
## Summary
Fixed broken installation URLs in README.md and SETUP_GUIDE.md that were returning 404 errors.

## Problem
The installation instructions reference `ddx-tools/ddx` repository which doesn't exist, causing 404 errors when users try to install DDx:

```bash
curl -fsSL https://raw.githubusercontent.com/ddx-tools/ddx/main/install.sh | bash
# Returns: 404 Not Found
```

## Solution
Updated all repository references to point to the correct repository `easel/ddx`:

**Files Updated:**
- `README.md`: Fixed 3 installation command URLs and multiple repository references
- `docs/SETUP_GUIDE.md`: Fixed installation URLs, GitHub links, and repository references

**Verified Working:**
```bash
curl -fsSL https://raw.githubusercontent.com/easel/ddx/main/install.sh | bash
# Returns: 200 OK with installation script
```

## Test Plan
- [x] Verified new URLs return 200 OK
- [x] Confirmed `install.sh` exists at correct location
- [x] Tested installation command works correctly
- [x] All repository links now point to existing repository

This fix resolves the immediate installation issue users are experiencing.

🤖 Generated with [Claude Code](https://claude.ai/code)