### PR TITLE
docs: link agent routing references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,13 @@
 # DDx Agent Instructions
 
+## Agent Routing Reference
+
+DDx agent routing rules live in ddx-agent and should be linked, not duplicated:
+
+- Profile catalog: https://github.com/DocumentDrivenDX/agent/blob/master/docs/routing/profiles.md
+- Override precedence: https://github.com/DocumentDrivenDX/agent/blob/master/docs/routing/override-precedence.md
+- Best-provider contract: https://github.com/DocumentDrivenDX/agent/blob/master/docs/routing/best-provider.md
+
 This repository uses DDx's built-in bead tracker for durable work management.
 
 ## Bead Policy

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,14 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 DDx (Document-Driven Development eXperience) is the shared infrastructure platform for document-driven development. It provides the tools that developers and workflow systems (like HELIX) use to manage the documents AI agents consume to build software.
 
+## Agent Routing Reference
+
+DDx agent routing behavior is documented in ddx-agent and should be linked, not duplicated:
+
+- Profile catalog: https://github.com/DocumentDrivenDX/agent/blob/master/docs/routing/profiles.md
+- Override precedence: https://github.com/DocumentDrivenDX/agent/blob/master/docs/routing/override-precedence.md
+- Best-provider contract: https://github.com/DocumentDrivenDX/agent/blob/master/docs/routing/best-provider.md
+
 DDx is one layer in a three-project stack:
 - **DDx** (this repo) — platform services: document library, bead tracker, agent service, personas, templates, git sync
 - **HELIX** (`~/Projects/helix`) — workflow methodology: phases, gates, supervisory dispatch, bounded actions


### PR DESCRIPTION
Companion PR for DocumentDrivenDX/agent bead agent-1f46cf22. Updates DDx agent instruction docs to link the ddx-agent routing profile catalog, override precedence, and best-provider contract instead of duplicating those rules.